### PR TITLE
Fix and simplify redirects

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,3 +32,7 @@ exclude:
 
 plugins:
   - jekyll-sitemap
+  - jekyll-redirect-from
+
+redirect_from:
+  json: false

--- a/events/pan-07/index.html
+++ b/events/pan-07/index.html
@@ -1,9 +1,3 @@
-<html>
-<head>
-<title>Webis Events</title>
-<meta http-equiv="refresh" content="0; URL=pan07-web">
-</head>
-<body>
-You should be automatically be redirected to the task page. If not, please use <a href="pan07-web">this link</a>.
-</body>
-</html>
+---
+redirect_to: events/pan-07/pan07-web
+---

--- a/events/pan-08/index.html
+++ b/events/pan-08/index.html
@@ -1,9 +1,3 @@
-<html>
-<head>
-<title>Webis Events</title>
-<meta http-equiv="refresh" content="0; URL=pan08-web">
-</head>
-<body>
-You should be automatically be redirected to the task page. If not, please use <a href="pan08-web">this link</a>.
-</body>
-</html>
+---
+redirect_to: events/pan-08/pan08-web
+---

--- a/events/panfire-11/index.html
+++ b/events/panfire-11/index.html
@@ -1,9 +1,3 @@
-<html>
-<head>
-<title>Webis Events</title>
-<meta http-equiv="refresh" content="0; URL=panfire11-web">
-</head>
-<body>
-You should be automatically be redirected to the task page. If not, please use <a href="panfire11-web">this link</a>.
-</body>
-</html>
+---
+redirect_to: events/panfire-11/panfire11-web
+---

--- a/events/puk-98/index.html
+++ b/events/puk-98/index.html
@@ -1,9 +1,3 @@
-<html>
-<head>
-<title>Webis Events</title>
-<meta http-equiv="refresh" content="0; URL=puk98-web">
-</head>
-<body>
-You should be automatically be redirected. If not, please use <a href="puk98-web">this link</a>.
-</body>
-</html>
+---
+redirect_to: events/puk-98/puk98-web
+---

--- a/events/semeval-19/index.html
+++ b/events/semeval-19/index.html
@@ -1,9 +1,3 @@
-<html>
-<head>
-<title>Webis Events</title>
-<meta http-equiv="refresh" content="0; URL=http://pan.webis.de/semeval19/semeval19-web">
-</head>
-<body>
-You should be automatically be redirected to the task page. If not, please use <a href="http://pan.webis.de/semeval19/semeval19-web">this link</a>.
-</body>
-</html>
+---
+redirect_to: http://pan.webis.de/semeval19/semeval19-web
+---

--- a/events/tir-04/index.html
+++ b/events/tir-04/index.html
@@ -1,9 +1,3 @@
-<html>
-<head>
-<title>Webis Events</title>
-<meta http-equiv="refresh" content="0; URL=tir04-web">
-</head>
-<body>
-You should be automatically be redirected to the task page. If not, please use <a href="tir04-web">this link</a>.
-</body>
-</html>
+---
+redirect_to: events/tir-04/tir04-web
+---

--- a/events/tir-05/index.html
+++ b/events/tir-05/index.html
@@ -1,9 +1,3 @@
-<html>
-<head>
-<title>Webis Events</title>
-<meta http-equiv="refresh" content="0; URL=tir05-web">
-</head>
-<body>
-You should be automatically be redirected to the task page. If not, please use <a href="tir05-web">this link</a>.
-</body>
-</html>
+---
+redirect_to: events/tir-05/tir05-web
+---

--- a/events/tir-06/index.html
+++ b/events/tir-06/index.html
@@ -1,9 +1,3 @@
-<html>
-<head>
-<title>Webis Events</title>
-<meta http-equiv="refresh" content="0; URL=tir06-web">
-</head>
-<body>
-You should be automatically be redirected to the task page. If not, please use <a href="tir06-web">this link</a>.
-</body>
-</html>
+---
+redirect_to: events/tir-06/tir06-web
+---

--- a/events/tir-07/index.html
+++ b/events/tir-07/index.html
@@ -1,9 +1,3 @@
-<html>
-<head>
-<title>Webis Events</title>
-<meta http-equiv="refresh" content="0; URL=tir07-web">
-</head>
-<body>
-You should be automatically be redirected to the task page. If not, please use <a href="tir07-web">this link</a>.
-</body>
-</html>
+---
+redirect_to: events/tir-07/tir07-web
+---

--- a/events/tir-08/index.html
+++ b/events/tir-08/index.html
@@ -1,9 +1,3 @@
-<html>
-<head>
-<title>Webis Events</title>
-<meta http-equiv="refresh" content="0; URL=tir08-web">
-</head>
-<body>
-You should be automatically be redirected to the task page. If not, please use <a href="tir08-web">this link</a>.
-</body>
-</html>
+---
+redirect_to: events/tir-08/tir08-web
+---

--- a/events/tir-09/index.html
+++ b/events/tir-09/index.html
@@ -1,9 +1,3 @@
-<html>
-<head>
-<title>Webis Events</title>
-<meta http-equiv="refresh" content="0; URL=tir09-web">
-</head>
-<body>
-You should be automatically be redirected to the task page. If not, please use <a href="tir09-web">this link</a>.
-</body>
-</html>
+---
+redirect_to: events/tir-09/tir09-web
+---

--- a/events/tir-10/index.html
+++ b/events/tir-10/index.html
@@ -1,9 +1,3 @@
-<html>
-<head>
-<title>Webis Events</title>
-<meta http-equiv="refresh" content="0; URL=tir10-web">
-</head>
-<body>
-You should be automatically be redirected to the task page. If not, please use <a href="tir10-web">this link</a>.
-</body>
-</html>
+---
+redirect_to: events/tir-10/tir10-web
+---

--- a/events/tir-11/index.html
+++ b/events/tir-11/index.html
@@ -1,9 +1,3 @@
-<html>
-<head>
-<title>Webis Events</title>
-<meta http-equiv="refresh" content="0; URL=tir11-web">
-</head>
-<body>
-You should be automatically be redirected to the task page. If not, please use <a href="tir11-web">this link</a>.
-</body>
-</html>
+---
+redirect_to: events/tir-11/tir11-web
+---

--- a/events/tir-12/index.html
+++ b/events/tir-12/index.html
@@ -1,9 +1,3 @@
-<html>
-<head>
-<title>Webis Events</title>
-<meta http-equiv="refresh" content="0; URL=tir12-web">
-</head>
-<body>
-You should be automatically be redirected to the task page. If not, please use <a href="tir12-web">this link</a>.
-</body>
-</html>
+---
+redirect_to: events/tir-12/tir12-web
+---

--- a/events/tir-13/index.html
+++ b/events/tir-13/index.html
@@ -1,9 +1,3 @@
-<html>
-<head>
-<title>Webis Events</title>
-<meta http-equiv="refresh" content="0; URL=tir13-web">
-</head>
-<body>
-You should be automatically be redirected to the task page. If not, please use <a href="tir13-web">this link</a>.
-</body>
-</html>
+---
+redirect_to: events/tir-13/tir13-web
+---

--- a/events/tir-14/index.html
+++ b/events/tir-14/index.html
@@ -1,9 +1,3 @@
-<html>
-<head>
-<title>Webis Events</title>
-<meta http-equiv="refresh" content="0; URL=tir14-web">
-</head>
-<body>
-You should be automatically be redirected to the task page. If not, please use <a href="tir14-web">this link</a>.
-</body>
-</html>
+---
+redirect_to: events/tir-14/tir14-web
+---

--- a/events/tir-15/index.html
+++ b/events/tir-15/index.html
@@ -1,9 +1,3 @@
-<html>
-<head>
-<title>Webis Events</title>
-<meta http-equiv="refresh" content="0; URL=tir15-web">
-</head>
-<body>
-You should be automatically be redirected to the task page. If not, please use <a href="tir15-web">this link</a>.
-</body>
-</html>
+---
+redirect_to: events/tir-15/tir15-web
+---

--- a/events/tir-16/index.html
+++ b/events/tir-16/index.html
@@ -1,9 +1,3 @@
-<html>
-<head>
-<title>Webis Events</title>
-<meta http-equiv="refresh" content="0; URL=tir16-web">
-</head>
-<body>
-You should be automatically be redirected to the task page. If not, please use <a href="tir16-web">this link</a>.
-</body>
-</html>
+---
+redirect_to: events/tir-16/tir16-web
+---

--- a/events/tir-17/index.html
+++ b/events/tir-17/index.html
@@ -1,9 +1,3 @@
-<html>
-<head>
-<title>Webis Events</title>
-<meta http-equiv="refresh" content="0; URL=tir17-web">
-</head>
-<body>
-You should be automatically be redirected to the task page. If not, please use <a href="tir17-web">this link</a>.
-</body>
-</html>
+---
+redirect_to: events/tir-17/tir17-web
+---

--- a/events/touche-20/index.html
+++ b/events/touche-20/index.html
@@ -1,9 +1,3 @@
-<html>
-<head>
-<title>Redirect</title>
-<meta http-equiv="refresh" content="0; URL=https://touche.webis.de/clef20/touche20-web">
-</head>
-<body>
-You should be automatically be redirected to the task page. If not, please use <a href="https://touche.webis.de/clef20/touche20-web">this link</a>.
-</body>
-</html>
+---
+redirect_to: https://touche.webis.de/clef20/touche20-web
+---

--- a/events/touche-20/organization.html
+++ b/events/touche-20/organization.html
@@ -1,0 +1,3 @@
+---
+redirect_to: https://touche.webis.de/clef20/touche20-web/index.html#index-organizing-committee
+---

--- a/events/touche-20/program.html
+++ b/events/touche-20/program.html
@@ -1,0 +1,3 @@
+---
+redirect_to: https://touche.webis.de/clef20/touche20-web/index.html#index-program
+---

--- a/events/touche-20/shared-task-1.html
+++ b/events/touche-20/shared-task-1.html
@@ -1,0 +1,3 @@
+---
+redirect_to: https://touche.webis.de/clef20/touche20-web/argument-retrieval-for-controversial-questions
+---

--- a/events/touche-20/shared-task-2.html
+++ b/events/touche-20/shared-task-2.html
@@ -1,0 +1,3 @@
+---
+redirect_to: https://touche.webis.de/clef20/touche20-web/argument-retrieval-for-comparative-questions
+---

--- a/events/touche-20/tira-guide-task-1.html
+++ b/events/touche-20/tira-guide-task-1.html
@@ -1,0 +1,3 @@
+---
+redirect_to: https://touche.webis.de/clef20/touche20-web/argument-retrieval-for-controversial-questions#tira-quickstart
+---

--- a/events/touche-20/tira-guide-task-2.html
+++ b/events/touche-20/tira-guide-task-2.html
@@ -1,0 +1,3 @@
+---
+redirect_to: https://touche.webis.de/clef20/touche20-web/argument-retrieval-for-comparative-questions#tira-quickstart
+---

--- a/events/touche-21/index.html
+++ b/events/touche-21/index.html
@@ -1,9 +1,3 @@
-<html>
-<head>
-<title>Redirect</title>
-<meta http-equiv="refresh" content="0; URL=https://touche.webis.de/clef21/touche21-web">
-</head>
-<body>
-You should be automatically be redirected to the task page. If not, please use <a href="https://touche.webis.de/clef21/touche21-web">this link</a>.
-</body>
-</html>
+---
+redirect_to: https://touche.webis.de/clef21/touche21-web
+---

--- a/events/touche-21/organization.html
+++ b/events/touche-21/organization.html
@@ -1,0 +1,3 @@
+---
+redirect_to: https://touche.webis.de/clef21/touche21-web/index.html#index-organizing-committee
+---

--- a/events/touche-21/program.html
+++ b/events/touche-21/program.html
@@ -1,0 +1,3 @@
+---
+redirect_to: https://touche.webis.de/clef21/touche21-web/index.html#index-program
+---

--- a/events/touche-21/shared-task-1.html
+++ b/events/touche-21/shared-task-1.html
@@ -1,0 +1,3 @@
+---
+redirect_to: https://touche.webis.de/clef21/touche21-web/argument-retrieval-for-controversial-questions
+---

--- a/events/touche-21/shared-task-2.html
+++ b/events/touche-21/shared-task-2.html
@@ -1,0 +1,3 @@
+---
+redirect_to: https://touche.webis.de/clef21/touche21-web/argument-retrieval-for-comparative-questions
+---

--- a/events/touche-21/tira-guide-task-1.html
+++ b/events/touche-21/tira-guide-task-1.html
@@ -1,0 +1,3 @@
+---
+redirect_to: https://touche.webis.de/clef21/touche21-web/argument-retrieval-for-controversial-questions#tira-quickstart
+---

--- a/events/touche-21/tira-guide-task-2.html
+++ b/events/touche-21/tira-guide-task-2.html
@@ -1,0 +1,3 @@
+---
+redirect_to: https://touche.webis.de/clef21/touche21-web/argument-retrieval-for-comparative-questions#tira-quickstart
+---

--- a/events/touche-22/index.html
+++ b/events/touche-22/index.html
@@ -1,9 +1,3 @@
-<html>
-<head>
-<title>Redirect</title>
-<meta http-equiv="refresh" content="0; URL=https://touche.webis.de/clef22/touche22-web">
-</head>
-<body>
-You should be automatically be redirected to the task page. If not, please use <a href="https://touche.webis.de/clef22/touche22-web">this link</a>.
-</body>
-</html>
+---
+redirect_to: https://touche.webis.de/clef22/touche22-web
+---

--- a/events/touche-22/shared-task-1.html
+++ b/events/touche-22/shared-task-1.html
@@ -1,0 +1,3 @@
+---
+redirect_to: https://touche.webis.de/clef22/touche22-web/argument-retrieval-for-controversial-questions.html
+---

--- a/events/touche-22/shared-task-2.html
+++ b/events/touche-22/shared-task-2.html
@@ -1,0 +1,3 @@
+---
+redirect_to: https://touche.webis.de/clef22/touche22-web/argument-retrieval-for-comparative-questions.html
+---

--- a/events/touche-22/shared-task-3.html
+++ b/events/touche-22/shared-task-3.html
@@ -1,0 +1,3 @@
+---
+redirect_to: https://touche.webis.de/clef22/touche22-web/image-retrieval-for-arguments.html
+---

--- a/events/touche-22/tira-guide-task-1.html
+++ b/events/touche-22/tira-guide-task-1.html
@@ -1,0 +1,3 @@
+---
+redirect_to: https://touche.webis.de/clef22/touche22-web/argument-retrieval-for-controversial-questions#tira-quickstart
+---

--- a/events/touche-22/tira-guide-task-2.html
+++ b/events/touche-22/tira-guide-task-2.html
@@ -1,0 +1,3 @@
+---
+redirect_to: https://touche.webis.de/clef22/touche22-web/argument-retrieval-for-comparative-questions#tira-quickstart
+---

--- a/events/wiqe-10/index.html
+++ b/events/wiqe-10/index.html
@@ -1,9 +1,3 @@
-<html>
-<head>
-<title>Webis Events</title>
-<meta http-equiv="refresh" content="0; URL=wiqe10-web">
-</head>
-<body>
-You should be automatically be redirected. If not, please use <a href="wiqe10-web">this link</a>.
-</body>
-</html>
+---
+redirect_to: events/wiqe-10/wiqe10-web
+---

--- a/impressum.html
+++ b/impressum.html
@@ -1,14 +1,3 @@
-<!DOCTYPE HTML>
-<html lang="en-US">
-<head>
-<meta charset="UTF-8">
-<meta http-equiv="refresh" content="0; url=https://webis.de/legal.html">
-<script type="text/javascript">
-window.location.href = "https://webis.de/legal.html"
-</script>
-<title>Page Redirection</title>
-</head>
-<body>
-If you are not redirected automatically, follow this <a href='https://webis.de/legal.html'>link to the legal page</a>.
-</body>
-</html>
+---
+redirect_to: legal
+---

--- a/lecturenotes/slides.html
+++ b/lecturenotes/slides.html
@@ -1,9 +1,3 @@
-<html>
-<head>
-<title>Lecturenotes Redirect</title>
-<meta http-equiv="refresh" content="0; URL=../lecturenotes.html">
-</head>
-<body>
-You should be automatically be redirected to the lecturenotes page. If not, please use <a href="../lecturenotes.html">this link</a>.
-</body>
-</html>
+---
+redirect_to: lecturenotes
+---


### PR DESCRIPTION
Using the `jekyll-redirect-from` plugin, redirects can be generated automatically.
Also, some old Touché URLs were inaccessible and with this PR will redirect to the new site.